### PR TITLE
Add authentication and sharing

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,46 +1,97 @@
 const express = require('express');
 const cors = require('cors');
 const bodyParser = require('body-parser');
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
+const { v4: uuidv4 } = require('uuid');
 
 const app = express();
 app.use(cors());
 app.use(bodyParser.json());
 
-let todos = [];
+const SECRET = process.env.JWT_SECRET || 'secretkey';
 
-// Get all todos
-app.get('/api/todos', (req, res) => {
-  res.json(todos);
+// In-memory user store
+let users = [];
+
+function authMiddleware(req, res, next) {
+  const auth = req.headers.authorization;
+  if (!auth) return res.status(401).json({ message: 'No token provided' });
+  const token = auth.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, SECRET);
+    req.userId = decoded.id;
+    next();
+  } catch (err) {
+    res.status(401).json({ message: 'Invalid token' });
+  }
+}
+
+// Registration
+app.post('/api/auth/register', async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ message: 'Email and password required' });
+  }
+  if (users.find(u => u.email === email)) {
+    return res.status(400).json({ message: 'User already exists' });
+  }
+  const hash = await bcrypt.hash(password, 10);
+  const user = { id: uuidv4(), email, passwordHash: hash, todos: [], shareId: uuidv4() };
+  users.push(user);
+  res.status(201).json({ message: 'Registered' });
 });
 
-// Add a new todo
-app.post('/api/todos', (req, res) => {
-  const todo = {
-    id: Date.now(),
-    text: req.body.text || '',
-    completed: false,
-  };
-  todos.push(todo);
+// Login
+app.post('/api/auth/login', async (req, res) => {
+  const { email, password } = req.body;
+  const user = users.find(u => u.email === email);
+  if (!user) return res.status(400).json({ message: 'Invalid credentials' });
+  const match = await bcrypt.compare(password, user.passwordHash);
+  if (!match) return res.status(400).json({ message: 'Invalid credentials' });
+  const token = jwt.sign({ id: user.id }, SECRET);
+  res.json({ token, shareId: user.shareId });
+});
+
+// Todos CRUD
+app.get('/api/todos', authMiddleware, (req, res) => {
+  const user = users.find(u => u.id === req.userId);
+  res.json(user.todos);
+});
+
+app.post('/api/todos', authMiddleware, (req, res) => {
+  const user = users.find(u => u.id === req.userId);
+  const todo = { id: uuidv4(), task: req.body.task || '', completed: false };
+  user.todos.push(todo);
   res.status(201).json(todo);
 });
 
-// Update a todo
-app.put('/api/todos/:id', (req, res) => {
-  const id = parseInt(req.params.id, 10);
-  const todo = todos.find((t) => t.id === id);
-  if (!todo) {
-    return res.sendStatus(404);
-  }
-  if (req.body.text !== undefined) todo.text = req.body.text;
+app.put('/api/todos/:id', authMiddleware, (req, res) => {
+  const user = users.find(u => u.id === req.userId);
+  const todo = user.todos.find(t => t.id === req.params.id);
+  if (!todo) return res.sendStatus(404);
+  if (req.body.task !== undefined) todo.task = req.body.task;
   if (req.body.completed !== undefined) todo.completed = req.body.completed;
   res.json(todo);
 });
 
-// Delete a todo
-app.delete('/api/todos/:id', (req, res) => {
-  const id = parseInt(req.params.id, 10);
-  todos = todos.filter((t) => t.id !== id);
+app.delete('/api/todos/:id', authMiddleware, (req, res) => {
+  const user = users.find(u => u.id === req.userId);
+  user.todos = user.todos.filter(t => t.id !== req.params.id);
   res.sendStatus(204);
+});
+
+app.delete('/api/todos/completed', authMiddleware, (req, res) => {
+  const user = users.find(u => u.id === req.userId);
+  user.todos = user.todos.filter(t => !t.completed);
+  res.sendStatus(204);
+});
+
+// Public share
+app.get('/api/share/:shareId', (req, res) => {
+  const user = users.find(u => u.shareId === req.params.shareId);
+  if (!user) return res.sendStatus(404);
+  res.json(user.todos);
 });
 
 const PORT = process.env.PORT || 4000;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,9 +8,12 @@
       "name": "todo-backend",
       "version": "1.0.0",
       "dependencies": {
+        "bcryptjs": "^2.4.3",
         "body-parser": "^1.20.2",
         "cors": "^2.8.5",
-        "express": "^4.18.2"
+        "express": "^4.18.2",
+        "jsonwebtoken": "^9.0.2",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "nodemon": "^2.0.22"
@@ -54,6 +57,12 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
     },
     "node_modules/binary-extensions": {
@@ -116,6 +125,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -276,6 +291,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -648,6 +672,109 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1216,6 +1343,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/server/package.json
+++ b/server/package.json
@@ -7,9 +7,12 @@
     "dev": "nodemon index.js"
   },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,22 @@
-// src/App.js
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { LoginPage } from './auth/LoginPage';
+import { RegisterPage } from './auth/RegisterPage';
+import { TodoPage } from './pages/TodoPage';
+import { SharedTodoPage } from './pages/SharedTodoPage';
+import './App.css';
 
-import { TodoPage } from "pages/TodoPage"
-import "App.css"
-
-const App = () => {
-  return <TodoPage />
+function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
+        <Route path="/todos" element={<TodoPage />} />
+        <Route path="/share/:shareId" element={<SharedTodoPage />} />
+        <Route path="*" element={<LoginPage />} />
+      </Routes>
+    </BrowserRouter>
+  );
 }
 
-export default App
+export default App;

--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -1,0 +1,17 @@
+export const registerUser = async (email, password) => {
+  const res = await fetch('/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  return res.json();
+};
+
+export const loginUser = async (email, password) => {
+  const res = await fetch('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  return res.json();
+};

--- a/src/api/todoApi.js
+++ b/src/api/todoApi.js
@@ -1,0 +1,37 @@
+import { getToken } from '../utils/authToken';
+
+const headers = () => ({
+  'Content-Type': 'application/json',
+  Authorization: `Bearer ${getToken()}`,
+});
+
+export const fetchTodos = async () => {
+  const res = await fetch('/api/todos', { headers: headers() });
+  return res.json();
+};
+
+export const addTodo = async (todo) => {
+  const res = await fetch('/api/todos', {
+    method: 'POST',
+    headers: headers(),
+    body: JSON.stringify(todo),
+  });
+  return res.json();
+};
+
+export const updateTodo = async (id, todo) => {
+  const res = await fetch(`/api/todos/${id}`, {
+    method: 'PUT',
+    headers: headers(),
+    body: JSON.stringify(todo),
+  });
+  return res.json();
+};
+
+export const deleteTodo = async (id) => {
+  await fetch(`/api/todos/${id}`, { method: 'DELETE', headers: headers() });
+};
+
+export const clearCompleted = async () => {
+  await fetch('/api/todos/completed', { method: 'DELETE', headers: headers() });
+};

--- a/src/auth/LoginPage.jsx
+++ b/src/auth/LoginPage.jsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useAuth } from './useAuth';
+
+export const LoginPage = () => {
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const result = await login(email, password);
+    if (result.token) {
+      navigate('/todos');
+    } else {
+      alert('Invalid credentials');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Login</h2>
+      <input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" />
+      <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" />
+      <button type="submit">Login</button>
+      <p>No account? <Link to="/register">Register</Link></p>
+    </form>
+  );
+};

--- a/src/auth/RegisterPage.jsx
+++ b/src/auth/RegisterPage.jsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export const RegisterPage = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const res = await fetch('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
+    const data = await res.json();
+    if (res.ok) {
+      alert('Registration successful! You can now log in.');
+      navigate('/login');
+    } else {
+      alert(data.message || 'Registration failed.');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Register</h2>
+      <input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" />
+      <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" />
+      <button type="submit">Register</button>
+    </form>
+  );
+};

--- a/src/auth/useAuth.js
+++ b/src/auth/useAuth.js
@@ -1,0 +1,32 @@
+import { useState, useEffect } from 'react';
+import { getToken, setToken, removeToken } from '../utils/authToken';
+
+export const useAuth = () => {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const stored = getToken();
+    if (stored) setUser({ token: stored });
+  }, []);
+
+  const login = async (email, password) => {
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ email, password }),
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const data = await res.json();
+    if (data.token) {
+      setToken(data.token);
+      setUser({ token: data.token, shareId: data.shareId });
+    }
+    return data;
+  };
+
+  const logout = () => {
+    removeToken();
+    setUser(null);
+  };
+
+  return { user, login, logout };
+};

--- a/src/components/TodoAdd.jsx
+++ b/src/components/TodoAdd.jsx
@@ -1,51 +1,30 @@
-// src/components/TodoAdd.jsx
-
-import { useContext } from "react";
-import { useForm } from "hooks/useForm";
-import { TodoContext } from "state/todoContext";
+import { useState, useContext } from 'react';
+import { TodoContext } from '../state/todoContext';
+import { addTodo } from '../api/todoApi';
 
 export const TodoAdd = () => {
-  const [{ task }, handleInputChange, reset] = useForm({
-    task: "",
-  });
-
+  const [task, setTask] = useState('');
   const { dispatch } = useContext(TodoContext);
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
+    if (!task.trim()) return;
 
-    if (task.trim().length === 0) {
-      return;
-    }
-
-    const todo = {
-      id: Date.now(),
-      task,
-      status: false,
-    };
-
-    dispatch({
-      type: "add",
-      payload: todo,
-    });
-
-    reset();
+    const newTodo = await addTodo({ task });
+    dispatch({ type: 'add', payload: newTodo });
+    setTask('');
   };
 
   return (
-    <form className="form">
+    <form className="form" onSubmit={handleSubmit}>
       <input
-        autoComplete="off"
-        className="form__input"
         type="text"
-        name="task"
-        placeholder="Add new task..."
+        className="form__input"
         value={task}
-        onChange={handleInputChange}
+        onChange={(e) => setTask(e.target.value)}
+        placeholder="Add new task..."
       />
-      <button className="form__button" type="submit" onClick={handleSubmit}>
-        +
-      </button>
+      <button className="form__button" type="submit">+</button>
     </form>
   );
 };

--- a/src/components/TodoClearCompleted.jsx
+++ b/src/components/TodoClearCompleted.jsx
@@ -1,31 +1,26 @@
-// src/components/TodoClearCompleted.jsx
-
-import { useContext, useEffect, useState } from "react";
-import { TodoContext } from "state/todoContext";
+import { useContext, useEffect, useState } from 'react';
+import { TodoContext } from '../state/todoContext';
+import { clearCompleted } from '../api/todoApi';
 
 export const TodoClearCompleted = () => {
   const { todos, dispatch } = useContext(TodoContext);
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const isAnyTodoCompleted = todos.some((todo) => todo.status === true);
-    setVisible(isAnyTodoCompleted);
+    const anyCompleted = todos.some(t => t.completed === true);
+    setVisible(anyCompleted);
   }, [todos]);
 
-  const handleClearCompleted = () => {
-    dispatch({
-      type: "clear",
-    });
+  const handleClearCompleted = async () => {
+    await clearCompleted();
+    dispatch({ type: 'clear' });
   };
 
   return (
     <>
       {visible && (
         <div className="todo-list__options">
-          <button
-            className="todo-list__options__button"
-            onClick={handleClearCompleted}
-          >
+          <button className="todo-list__options__button" onClick={handleClearCompleted}>
             Clear completed tasks
           </button>
         </div>

--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -1,38 +1,30 @@
-// src/components/TodoList.jsx
-
-import { useContext } from "react";
-import { TodoContext } from "state/todoContext";
-import { TodoListItem } from "components/TodoListItem";
+import { useContext } from 'react';
+import { TodoContext } from '../state/todoContext';
+import { TodoListItem } from './TodoListItem';
+import { updateTodo, deleteTodo } from '../api/todoApi';
 
 export const TodoList = () => {
   const { todos, dispatch } = useContext(TodoContext);
 
-  const handleToggle = (todoId) => {
-    dispatch({
-      type: "toggle",
-      payload: todoId,
-    });
+  const handleToggle = async (id) => {
+    const todo = todos.find(t => t.id === id);
+    await updateTodo(id, { completed: !todo.completed });
+    dispatch({ type: 'toggle', payload: id });
   };
 
-  const handleModify = (todo) => {
-    if (todo.task.trim().length === 0) return
-
-    dispatch({
-      type: "modify",
-      payload: todo,
-    });
+  const handleModify = async (todo) => {
+    const updated = await updateTodo(todo.id, { task: todo.task });
+    dispatch({ type: 'modify', payload: updated });
   };
 
-  const handleDelete = (todoId) => {
-    dispatch({
-      type: "delete",
-      payload: todoId,
-    });
+  const handleDelete = async (id) => {
+    await deleteTodo(id);
+    dispatch({ type: 'delete', payload: id });
   };
 
   return (
     <ul className="todo-list">
-      {todos.map((todo) => (
+      {todos.map(todo => (
         <TodoListItem
           key={todo.id}
           todo={todo}

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,6 @@
-// src/insex.js
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
 
-import React from "react";
-import ReactDOM from "react-dom/client";
-import App from "./App";
-
-const root = ReactDOM.createRoot(document.getElementById("root"));
+const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(<App />);

--- a/src/pages/SharedTodoPage.jsx
+++ b/src/pages/SharedTodoPage.jsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+export const SharedTodoPage = () => {
+  const { shareId } = useParams();
+  const [todos, setTodos] = useState([]);
+
+  useEffect(() => {
+    const loadTodos = async () => {
+      const res = await fetch(`/api/share/${shareId}`);
+      const data = await res.json();
+      setTodos(data);
+    };
+    loadTodos();
+  }, [shareId]);
+
+  return (
+    <div>
+      <h1>Shared Todo List</h1>
+      <ul>
+        {todos.map(todo => (
+          <li key={todo.id}>{todo.task}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/src/pages/TodoPage.jsx
+++ b/src/pages/TodoPage.jsx
@@ -1,24 +1,41 @@
-// src/pages/TodoPage.jsx
-
-import { useEffect, useReducer } from "react";
-import { todoReducer } from "state/todoReducer";
-import { TodoContext } from "state/todoContext";
-import { TodoAdd } from "components/TodoAdd";
-import { TodoList } from "components/TodoList";
-import { TodoClearCompleted } from "components/TodoClearCompleted";
-import { initialData } from "consts/initialData";
+import { useEffect, useReducer } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { todoReducer } from '../state/todoReducer';
+import { TodoContext } from '../state/todoContext';
+import { TodoAdd } from '../components/TodoAdd';
+import { TodoList } from '../components/TodoList';
+import { TodoClearCompleted } from '../components/TodoClearCompleted';
+import { fetchTodos } from '../api/todoApi';
+import { useAuth } from '../auth/useAuth';
 
 export const TodoPage = () => {
-  const [todos, dispatch] = useReducer(todoReducer, [], initialData);
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [todos, dispatch] = useReducer(todoReducer, []);
 
   useEffect(() => {
-    localStorage.setItem("todos", JSON.stringify(todos));
-  }, [todos]);
+    if (!user) {
+      navigate('/login');
+      return;
+    }
+    const load = async () => {
+      const data = await fetchTodos();
+      dispatch({ type: 'load', payload: data });
+    };
+    load();
+  }, [user, navigate]);
+
+  const shareUrl = user ? `${window.location.origin}/share/${user.shareId}` : '';
 
   return (
     <TodoContext.Provider value={{ todos, dispatch }}>
       <main className="card">
         <h1 className="card__title">Todo List</h1>
+        {user && (
+          <p>
+            Share link: <a href={shareUrl}>{shareUrl}</a>
+          </p>
+        )}
         <TodoAdd />
         <hr />
         <TodoList />

--- a/src/state/todoReducer.js
+++ b/src/state/todoReducer.js
@@ -3,25 +3,25 @@
 
 export const todoReducer = (state = [], action) => {
   switch (action.type) {
-    case "add":
+    case 'load':
+      return action.payload;
+    case 'add':
       return [...state, action.payload];
 
-    case "delete":
+    case 'delete':
       return state.filter((todo) => todo.id !== action.payload);
 
-    case "modify":
+    case 'modify':
       return state.map((todo) =>
-        todo.id === action.payload.id
-          ? { ...todo, task: action.payload.task }
-          : todo
+        todo.id === action.payload.id ? { ...todo, task: action.payload.task } : todo
       );
 
-    case "clear":
-      return state.filter((todo) => todo.status !== true);
+    case 'clear':
+      return state.filter((todo) => !todo.completed);
 
-    case "toggle":
+    case 'toggle':
       return state.map((todo) =>
-        todo.id === action.payload ? { ...todo, status: !todo.status } : todo
+        todo.id === action.payload ? { ...todo, completed: !todo.completed } : todo
       );
 
     default:

--- a/src/utils/authToken.js
+++ b/src/utils/authToken.js
@@ -1,0 +1,5 @@
+const KEY = 'auth_token';
+
+export const getToken = () => localStorage.getItem(KEY);
+export const setToken = (token) => localStorage.setItem(KEY, token);
+export const removeToken = () => localStorage.removeItem(KEY);


### PR DESCRIPTION
## Summary
- add login/registration components and authentication hook
- store JWT token in localStorage
- create API helpers for todos and auth
- implement sharing page and router
- enhance reducer and components to use backend
- add Node backend with JWT auth and share links

## Testing
- `npm test --silent --forceExit`


------
https://chatgpt.com/codex/tasks/task_e_686120c55f188320a4e6439f5c1b711f